### PR TITLE
Rename 'writeFile' functions in general scope to 'writeOutput'

### DIFF
--- a/lib/mercyhill/newslettermanager.js
+++ b/lib/mercyhill/newslettermanager.js
@@ -13,7 +13,7 @@ function pushFeeds(item)
     }); 
 }
 
-function writeFiles()
+function writeOutput()
 {
     config.feedManagers.forEach(function(entry) {
         entry.write();
@@ -50,5 +50,5 @@ function readItem(results, item)
 
 exports.processItem = processItem;
 exports.readItem = readItem;
-exports.writeFiles = writeFiles;
+exports.writeOutput = writeOutput;
 exports.config = config;

--- a/lib/rssfeedparser.js
+++ b/lib/rssfeedparser.js
@@ -70,7 +70,7 @@ function processFeed(err) {
 
     if(config.writeFiles)
     {
-        manager.writeFiles(function(err) {
+        manager.writeOutput(function(err) {
             if (err) return console.log(err);
         });
     }


### PR DESCRIPTION
Rename 'writeFile' functions in general scope to 'writeOutput'

Interface output doesn't always have to be files; better to be clear about that.