### PR TITLE
Moved description replace regexes to config

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,4 +9,22 @@ config.feedManagers = [
     require('./lib/mercyhill/feeds/alexa-serveteamfeedmanager.js')
 ];
 
+config.replaceMap = new Map();
+// Remove all text between square brackets, and the brackets too.
+config.replaceMap.set(/ *\[[^\]]*]/g, '');
+// Replace 'click here' text that is meant for the emails.
+// TODO: Make this capture 'click here\s.*.' Need to capture any generic 'click here to do x'    
+config.replaceMap.set(/(click here)(?:(\s)*to learn more)?/gim, '');
+// Replace text that is meant as a link for the emails.    
+config.replaceMap.set(/^(Sermon Series)$/gim, '');
+// Replace text that is meant as a link for the emails.     
+config.replaceMap.set(/(Listen to Sermons Here.)/gim, '');
+// Replace text that is meant as a link for the emails.     
+config.replaceMap.set(/(Set up an E-Giving account today.)/gim, '');
+// Replace text that is meant for the emails.
+config.replaceMap.set(/Reply to this (email|e-mail)./gim, '');
+config.replaceMap.set(/rsvp and more info here/gim, '');
+// Replace stray character that regex didn't get.
+config.replaceMap.set(/^\]/, '');    
+
 module.exports = config;

--- a/lib/mercyhill/config.js
+++ b/lib/mercyhill/config.js
@@ -4,13 +4,17 @@ function initialize(input)
     {
         config.redirectionUrl = input.redirectionUrl || config.redirectionUrl;
         config.feedManagers = input.feedManagers || config.feedManagers;
+        config.replaceMap = input.replaceMap || config.replaceMap;
     }
 }
 
 var config = {};
 
+// Defaults
 config.redirectionUrl = '';
 config.feedManagers = [];
+config.replaceMap = new Map();
+
 config.initialize = initialize;
 
 module.exports = config;

--- a/lib/mercyhill/newslettermanager.js
+++ b/lib/mercyhill/newslettermanager.js
@@ -33,7 +33,7 @@ function processItem(item)
 
     newsletterparser.buildFooter(item);
 
-    newsletterparser.filterDescription(item, match.index);
+    newsletterparser.filterDescription(item, match.index, config);
 
     newsletterparser.buildDescription(item);
 

--- a/lib/mercyhill/newsletterparser.js
+++ b/lib/mercyhill/newsletterparser.js
@@ -4,7 +4,7 @@ var exports = module.exports = {};
 
 var htmlToText = require('html-to-text');
 
-function filterDescription(item, colorIndex)
+function filterDescription(item, colorIndex, config)
 {
     // Remove all text after the team color.
     if(colorIndex != null)
@@ -15,28 +15,9 @@ function filterDescription(item, colorIndex)
     // Remove all text before the first link or image; this is usually fluff.
     item.plaintext = item.plaintext.substring(item.plaintext.indexOf("["));
 
-    // Remove all text between square brackets, and the brackets too.
-    item.plaintext = item.plaintext.replace(/ *\[[^\]]*]/g, '');
-
-    // Replace 'click here' text that is meant for the emails.
-    // TODO: Make this capture 'click here\s.*.' Need to capture any generic 'click here to do x'
-    item.plaintext = item.plaintext.replace(/(click here)(?:(\s)*to learn more)?/gim, '');
-
-    // Replace text that is meant as a link for the emails.
-    item.plaintext = item.plaintext.replace(/^(Sermon Series)$/gim, '');
-
-    // Replace text that is meant as a link for the emails.
-    item.plaintext = item.plaintext.replace(/(Listen to Sermons Here.)/gim, '');
-
-    // Replace text that is meant as a link for the emails.
-    item.plaintext = item.plaintext.replace(/(Set up an E-Giving account today.)/gim, '');
-
-    // Replace text that is meant for the emails.
-    item.plaintext = item.plaintext.replace(/Reply to this (email|e-mail)./gim, '');
-    item.plaintext = item.plaintext.replace(/rsvp and more info here/gim, '');
-
-    // Replace stray character that regex didn't get.
-    item.plaintext = item.plaintext.replace(/^\]/, '');   
+    config.replaceMap.forEach(function (newString, old) {
+      item.plaintext = item.plaintext.replace(old, newString);
+    }); 
 }
 
 function buildDescription(item)


### PR DESCRIPTION
Moved regex literals for cleaning up the newsletter plaintext out to the
root config file.  This will make it easier to catch and clean up subtle
changes in the newsletter over time without having to touch the actual
code.