### PR TITLE
Quick workaround for end of serve team colors

### DIFF
--- a/lib/mercyhill/newslettermanager.js
+++ b/lib/mercyhill/newslettermanager.js
@@ -30,10 +30,11 @@ function processItem(item)
     item.rawPlainText = htmlToText.fromString(item.rawHtml);
 
     var match = newsletterparser.buildServeTeam(item);
+    var colorIndex = match != null ? match.index : null;
 
     newsletterparser.buildFooter(item);
 
-    newsletterparser.filterDescription(item, match.index, config);
+    newsletterparser.filterDescription(item, colorIndex, config);
 
     newsletterparser.buildDescription(item);
 

--- a/lib/mercyhill/newsletterparser.js
+++ b/lib/mercyhill/newsletterparser.js
@@ -11,6 +11,10 @@ function filterDescription(item, colorIndex, config)
     {
         item.plaintext = item.rawPlainText.substring(0, colorIndex);
     }
+    else
+    {
+        item.plaintext = item.rawPlainText.substring(0, item.rawPlainText.indexOf("Set up an E-Giving"));        
+    }
 
     // Remove all text before the first link or image; this is usually fluff.
     item.plaintext = item.plaintext.substring(item.plaintext.indexOf("["));


### PR DESCRIPTION
Quick workaround for end of serve team colors

* Serve Team colors likely won't be continuing going forward; added conditional logic to derive the footer differently if color string isn't present.
* This was previously breaking on null reference because footer was being derived by color string, which no longer exists.