### PR TITLE
Source redirectUrl from feed items

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@ var config = {};
 config.feedUrl = 'http://us2.campaign-archive2.com/feed?u=2f2d857b4480a0883c6740273&id=7638673db2';
 config.desiredItems = 1;
 
+config.redirectionUrlAsFeedItem = true;
 config.redirectionUrl = 'https://www.mercyhillshep.org/';
 config.feedManagers = [
     require('./lib/mercyhill/feeds/alexa-newsletterfeedmanager.js'),

--- a/lib/mercyhill/config.js
+++ b/lib/mercyhill/config.js
@@ -2,6 +2,7 @@ function initialize(input)
 {
     if(input != null)
     {
+        config.redirectionUrlAsFeedItem = input.redirectionUrlAsFeedItem || config.redirectionUrlAsFeedItem;        
         config.redirectionUrl = input.redirectionUrl || config.redirectionUrl;
         config.feedManagers = input.feedManagers || config.feedManagers;
         config.replaceMap = input.replaceMap || config.replaceMap;
@@ -11,6 +12,7 @@ function initialize(input)
 var config = {};
 
 // Defaults
+config.redirectionUrlAsFeedItem = true;
 config.redirectionUrl = '';
 config.feedManagers = [];
 config.replaceMap = new Map();

--- a/lib/mercyhill/newslettermanager.js
+++ b/lib/mercyhill/newslettermanager.js
@@ -48,7 +48,7 @@ function readItem(results, item)
     results.push({
         updateDate: item.pubdate,
         titleText: item.title,
-        redirectionUrl: config.redirectionUrl,
+        redirectionUrl: config.redirectionUrlAsFeedItem ? item.link : config.redirectionUrl,
         rawHtml: item.description,
         uid: item.guid
     }); 


### PR DESCRIPTION
Resolves #8 - In Alexa app, when user clicks on the link for the mercy
hill item, it will link to the current week's newsletter in the web-view
of the mailchimp rss feed.